### PR TITLE
Fix toggleHighlightUnderCursor by changing order of handling objects …

### DIFF
--- a/src/com/innogames/as3communicator/controllers/APIController.as
+++ b/src/com/innogames/as3communicator/controllers/APIController.as
@@ -320,8 +320,8 @@ package com.innogames.as3communicator.controllers
 			var objCurrent:DisplayObject;
 			var arrObjects:Array = this.objParentContainer.getObjectsUnderPoint(new Point(evt.stageX, evt.stageY));
 
-			for each(var obj:DisplayObject in arrObjects)
-			{
+			for (var i:int = arrObjects.length - 1 ; i >= 0; i--) {
+				var obj:DisplayObject = arrObjects[i];
 				if(obj.parent && obj.parent is InteractiveObject)
 				{
 					obj = obj.parent;


### PR DESCRIPTION
Fix toggleHighlightUnderCursor by changing order of handling objects from  getObjectsUnderPoint array.

getObjectsUnderPoint method return elements in an order from the lowest on stage to highest. That means that first object of an array is the lowest and if it has a mouse click event we always will take this one object for toggleHighlightUnderCursor highlighting logic which looks not correct.

I changed order of handling these objects to vice versa.
